### PR TITLE
Update Exercício 051.py

### DIFF
--- a/Mundo 02/Exercícios Corrigidos/Exercício 051.py
+++ b/Mundo 02/Exercícios Corrigidos/Exercício 051.py
@@ -6,7 +6,7 @@ No final, mostre os 10 primeiros termos dessa progressão.
 """
 primeiro = int(input('Primeiro termo: '))
 razao = int(input('Razão: '))
-decimo = primeiro + (10 - 1) * razao
-for c in range(primeiro, decimo + razao, razao):
-    print('{}'.format(c), end=' → ')
+for c in range(10):
+    print(f'{primeiro}', end=' → ')
+    primeiro += razao
 print('ACABOU')


### PR DESCRIPTION
feat(ex051): add simpler and more readable solution for arithmetic progression

Sugestão de melhoria para o exercício 051 - Progressão Aritmética

Olá! 👋

Notei que a solução atual utiliza o cálculo do último termo da PA para definir o intervalo do `range`. Embora esteja correta, gostaria de sugerir uma alternativa mais simples e direta, que pode ser mais fácil de entender para iniciantes.

Minha proposta:
- Usar `range(10)` para iterar os 10 primeiros termos
- Somar a razão a cada passo, mantendo a clareza
- Permitir o uso de `float` para maior flexibilidade

Acredito que essa abordagem pode tornar o exercício mais acessível para quem está começando.

Obrigado pelo ótimo conteúdo! 😊
